### PR TITLE
Import submodules automatically

### DIFF
--- a/airsonic-main/build.gradle
+++ b/airsonic-main/build.gradle
@@ -3,6 +3,9 @@ plugins {
 }
 
 ext {
+    withoutSLF4J = {
+        exclude group: 'org.slf4j', module: 'slf4j-simple'
+    }
     withoutAudioPlayerExclusions = {
         exclude group: 'org.slf4j', module: 'slf4j-simple'
         exclude group: 'commons-io', module: 'commons-io'
@@ -20,8 +23,8 @@ ext {
 }
 
 dependencies {
-    implementation project(':subsonic-rest-api')
-    implementation project(':airsonic-sonos-api')
+    implementation project(path: ':subsonic-rest-api', configuration: 'jaxb2'), withoutSLF4J
+    implementation project(path: ':airsonic-sonos-api')
 
     // Java Audio Player
     implementation 'com.github.biconou:AudioPlayer:0.2.5', withoutAudioPlayerExclusions
@@ -30,16 +33,16 @@ dependencies {
     implementation 'io.dropwizard.metrics:metrics-core:3.1.0'
 
     // Spring
-    implementation 'org.springframework.boot:spring-boot-starter-web:1.5.18.RELEASE', withoutSpringTomcat
+    implementation 'org.springframework.boot:spring-boot-starter-web:1.4.1.RELEASE', withoutSpringTomcat
     providedCompile 'javax.servlet.jsp:javax.servlet.jsp-api:2.3.1'
-    implementation 'org.springframework.boot:spring-boot-starter-jdbc:1.5.18.RELEASE'
-    implementation 'org.springframework.boot:spring-boot-starter-security:1.5.18.RELEASE'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test:1.5.18.RELEASE'
-    testImplementation 'org.springframework.security:spring-security-test:4.2.10.RELEASE'
-    implementation 'org.springframework.security:spring-security-ldap:4.2.10.RELEASE'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc:1.4.1.RELEASE'
+    implementation 'org.springframework.boot:spring-boot-starter-security:1.4.1.RELEASE'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test:1.4.1.RELEASE'
+    testImplementation 'org.springframework.security:spring-security-test:4.1.3.RELEASE'
+    implementation 'org.springframework.security:spring-security-ldap:4.1.3.RELEASE'
     implementation 'com.auth0:java-jwt:3.3.0'
-    implementation 'org.springframework.ldap:spring-ldap-core:2.3.2.RELEASE'
-    implementation 'org.springframework.security:spring-security-taglibs:4.2.10.RELEASE'
+    implementation 'org.springframework.ldap:spring-ldap-core:2.1.0.RELEASE'
+    implementation 'org.springframework.security:spring-security-taglibs:4.1.3.RELEASE'
 
     // TagLibs
     implementation 'org.apache.taglibs:taglibs-standard-impl:1.2.5'
@@ -93,7 +96,7 @@ dependencies {
     implementation 'com.hoodcomputing:natpmp:0.1'
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.springframework:spring-test:4.3.21.RELEASE'
+    testImplementation 'org.springframework:spring-test:4.3.3.RELEASE'
     testImplementation 'org.mockito:mockito-core:1.10.19'
     implementation 'org.assertj:assertj-core:2.6.0'
 
@@ -128,7 +131,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:1.7.25'
 
     // Embedded tomcat
-    implementation 'org.springframework.boot:spring-boot-starter-tomcat:1.5.18.RELEASE'
+    implementation 'org.springframework.boot:spring-boot-starter-tomcat:1.4.1.RELEASE'
     implementation 'org.apache.tomcat.embed:tomcat-embed-jasper:8.5.35'
 
     implementation 'com.fasterxml.jackson.core:jackson-core:2.9.6'

--- a/airsonic-main/build.gradle
+++ b/airsonic-main/build.gradle
@@ -22,6 +22,19 @@ ext {
     }
 }
 
+sourceSets {
+    main {
+        java {
+            srcDirs += file("${project.rootDir}/airsonic-sonos-api/build/generated/main/java")
+            srcDirs += file("${project.rootDir}/subsonic-rest-api/build/generated/main/java")
+        }
+        resources {
+            srcDirs += file("${project.rootDir}/airsonic-sonos-api/src/main/resources")
+            srcDirs += file("${project.rootDir}/subsonic-rest-api/src/main/resources")
+        }
+    }
+}
+
 dependencies {
     implementation project(path: ':subsonic-rest-api', configuration: 'jaxb2'), withoutSLF4J
     implementation project(path: ':airsonic-sonos-api')
@@ -142,5 +155,7 @@ dependencies {
     runtime 'mysql:mysql-connector-java:5.1.43'
     runtime 'org.mariadb.jdbc:mariadb-java-client:2.1.2'
 }
+
+compileJava.dependsOn ':subsonic-rest-api:compileJava', ':airsonic-sonos-api:compileJava'
 
 description = 'Airsonic Main'


### PR DESCRIPTION
This PR allows the Gradle buildscript to access the `subsonic-rest-api` and `airsonic-sonos-api` modules without importing them manually.